### PR TITLE
References updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ Contains integration testing for powsybl library blocks
 
 ## Test plan references updating
 
-When breaking changes are introduced and the references must be updated you can automatically update references by launching the two tests :
+When breaking changes are introduced and the references must be updated you can automatically update references by launching the two main in classes :
 
-- LoadFlowIntegrationTest.updateLoadFlowReference
-- SecurityAnalysisIntegrationTest.updateSaReference
+- LoadFlowTestPlanUpdater
+- SecurityAnalysisTestPlanUpdater
 
-Those two tests iterate on the test plans, execute them and override the reference files associated.
+Those two mains iterate on the test plans, execute them and override the reference files associated.
 
 You can then add the modified file to be commited.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # powsybl-integration-test
 Contains integration testing for powsybl library blocks
+
+## Test plan references updating
+
+When breaking changes are introduced and the references must be updated you can automatically update references by launching the two tests :
+
+- LoadFlowIntegrationTest.updateLoadFlowReference
+- SecurityAnalysisIntegrationTest.updateSaReference
+
+Those two tests iterate on the test plans, execute them and override the reference files associated.
+
+You can then add the modified file to be commited.

--- a/src/main/java/com/powsybl/integrationtest/jsonconfig/TestPlanReader.java
+++ b/src/main/java/com/powsybl/integrationtest/jsonconfig/TestPlanReader.java
@@ -14,6 +14,7 @@ import com.powsybl.integrationtest.model.TestPlan;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 
 /**
  * A component that reads files and outputs
@@ -31,5 +32,5 @@ public interface TestPlanReader<P extends ComputationParameters, R extends Compu
      * @throws IllegalArgumentException if file does not comply to the expected format
      * @throws IOException              if file cannot be read correctly
      */
-    TestPlan<P, R, T> extractTestPlan(InputStream input) throws IOException, URISyntaxException;
+    TestPlan<P, R, T> extractTestPlan(InputStream input, Path resourcePath) throws IOException, URISyntaxException;
 }

--- a/src/main/java/com/powsybl/integrationtest/loadflow/jsonconfig/LoadFlowTestPlanReader.java
+++ b/src/main/java/com/powsybl/integrationtest/loadflow/jsonconfig/LoadFlowTestPlanReader.java
@@ -61,7 +61,7 @@ public class LoadFlowTestPlanReader implements TestPlanReader<LoadFlowComputatio
      * @return the built LoadFlowTestCase
      * @throws IOException if provided information is not reachable for some reason
      */
-    public static LoadFlowTestCase buildFromJson(LoadFlowTestCaseJson testCaseJson, Path resourcePath) throws IOException, URISyntaxException {
+    public static LoadFlowTestCase buildFromJson(LoadFlowTestCaseJson testCaseJson, Path resourcePath) {
 
         LoadFlowParameters inputParameters = JsonLoadFlowParameters.read(
                 Objects.requireNonNull(resourcePath.resolve(testCaseJson.getInputParameters())));

--- a/src/main/java/com/powsybl/integrationtest/loadflow/jsonconfig/LoadFlowTestPlanReader.java
+++ b/src/main/java/com/powsybl/integrationtest/loadflow/jsonconfig/LoadFlowTestPlanReader.java
@@ -39,10 +39,14 @@ public class LoadFlowTestPlanReader implements TestPlanReader<LoadFlowComputatio
         objectMapper = JsonUtil.createObjectMapper().registerModule(new LoadFlowTestCaseModule());
     }
 
+    public LoadFlowTestPlanJson readTestPlan(InputStream input) throws IOException {
+        return objectMapper.readValue(input, LoadFlowTestPlanJson.class);
+    }
+
     @Override
     public TestPlan<LoadFlowComputationParameters, LoadFlowComputationResults, LoadFlowTestCase> extractTestPlan(InputStream input)
             throws IOException, URISyntaxException {
-        LoadFlowTestPlanJson lftpJson = objectMapper.readValue(input, LoadFlowTestPlanJson.class);
+        LoadFlowTestPlanJson lftpJson = readTestPlan(input);
         List<LoadFlowTestCase> testCases = new ArrayList<>();
         for (LoadFlowTestCaseJson testCaseJson : lftpJson.getTestCases()) {
             testCases.add(buildFromJson(testCaseJson));
@@ -57,7 +61,7 @@ public class LoadFlowTestPlanReader implements TestPlanReader<LoadFlowComputatio
      * @return the built LoadFlowTestCase
      * @throws IOException if provided information is not reachable for some reason
      */
-    private static LoadFlowTestCase buildFromJson(LoadFlowTestCaseJson testCaseJson) throws IOException, URISyntaxException {
+    public static LoadFlowTestCase buildFromJson(LoadFlowTestCaseJson testCaseJson) throws IOException, URISyntaxException {
         Class<LoadFlowTestPlanReader> cls = LoadFlowTestPlanReader.class;
 
         LoadFlowParameters inputParameters = JsonLoadFlowParameters.read(

--- a/src/main/java/com/powsybl/integrationtest/loadflow/jsonconfig/LoadFlowTestPlanReader.java
+++ b/src/main/java/com/powsybl/integrationtest/loadflow/jsonconfig/LoadFlowTestPlanReader.java
@@ -44,12 +44,12 @@ public class LoadFlowTestPlanReader implements TestPlanReader<LoadFlowComputatio
     }
 
     @Override
-    public TestPlan<LoadFlowComputationParameters, LoadFlowComputationResults, LoadFlowTestCase> extractTestPlan(InputStream input)
+    public TestPlan<LoadFlowComputationParameters, LoadFlowComputationResults, LoadFlowTestCase> extractTestPlan(InputStream input, Path resourcePath)
             throws IOException, URISyntaxException {
         LoadFlowTestPlanJson lftpJson = readTestPlan(input);
         List<LoadFlowTestCase> testCases = new ArrayList<>();
         for (LoadFlowTestCaseJson testCaseJson : lftpJson.getTestCases()) {
-            testCases.add(buildFromJson(testCaseJson));
+            testCases.add(buildFromJson(testCaseJson, resourcePath));
         }
         return new TestPlan<>(testCases);
     }
@@ -61,18 +61,16 @@ public class LoadFlowTestPlanReader implements TestPlanReader<LoadFlowComputatio
      * @return the built LoadFlowTestCase
      * @throws IOException if provided information is not reachable for some reason
      */
-    public static LoadFlowTestCase buildFromJson(LoadFlowTestCaseJson testCaseJson) throws IOException, URISyntaxException {
-        Class<LoadFlowTestPlanReader> cls = LoadFlowTestPlanReader.class;
+    public static LoadFlowTestCase buildFromJson(LoadFlowTestCaseJson testCaseJson, Path resourcePath) throws IOException, URISyntaxException {
 
         LoadFlowParameters inputParameters = JsonLoadFlowParameters.read(
-                Objects.requireNonNull(cls.getResourceAsStream("/" + testCaseJson.getInputParameters())));
-        Path networkFilePath = Path.of(Objects.requireNonNull(
-                cls.getResource("/" + testCaseJson.getInputNetwork())).toURI());
+                Objects.requireNonNull(resourcePath.resolve(testCaseJson.getInputParameters())));
+        Path networkFilePath = Objects.requireNonNull(resourcePath.resolve(testCaseJson.getInputNetwork()));
         Network inputNetwork = Network.read(Objects.requireNonNull(networkFilePath));
         LoadFlowResult expectedResults = LoadFlowResultDeserializer.read(
-                Objects.requireNonNull(cls.getResourceAsStream("/" + testCaseJson.getExpectedResults())));
-        Path expectedNetworkPath = Path.of(Objects.requireNonNull(
-                cls.getResource("/" + testCaseJson.getExpectedNetwork())).toURI());
+                Objects.requireNonNull(resourcePath.resolve(testCaseJson.getExpectedResults())));
+        Path expectedNetworkPath = Objects.requireNonNull(
+                resourcePath.resolve(testCaseJson.getExpectedNetwork()));
         Network expectedNetwork = Network.read(Objects.requireNonNull(expectedNetworkPath));
 
         return new LoadFlowTestCase(testCaseJson.getId(),

--- a/src/main/java/com/powsybl/integrationtest/model/AbstractTestRunner.java
+++ b/src/main/java/com/powsybl/integrationtest/model/AbstractTestRunner.java
@@ -27,7 +27,7 @@ public abstract class AbstractTestRunner<P extends ComputationParameters, R exte
     @Override
     public List<String> runTests(TestCase<P, R> testCase) {
         LOGGER.debug("Running calculation on testcase [" + testCase.getId()  + "]");
-        R actualResults = getComputationRunner().computeResults(testCase.getParameters());
+        R actualResults = runTestsWithoutChecks(testCase);
         LOGGER.debug("Now comparing results and expectations for testcase [" + testCase.getId()  + "] ...");
         List<String> errors = performIdentityChecks("[" + testCase.getId() + "] ", actualResults,
                 testCase.getExpectedResults());
@@ -39,6 +39,11 @@ public abstract class AbstractTestRunner<P extends ComputationParameters, R exte
             }
         }
         return errors;
+    }
+
+    @Override
+    public R runTestsWithoutChecks(TestCase<P, R> testCase) {
+        return getComputationRunner().computeResults(testCase.getParameters());
     }
 
     /**

--- a/src/main/java/com/powsybl/integrationtest/model/TestRunner.java
+++ b/src/main/java/com/powsybl/integrationtest/model/TestRunner.java
@@ -24,4 +24,6 @@ public interface TestRunner<P extends ComputationParameters, R extends Computati
      * @return a list containing all error messages. Empty if no error was found.
      */
     List<String> runTests(TestCase<P, R> testCase);
+
+    R runTestsWithoutChecks(TestCase<P, R> testCase);
 }

--- a/src/main/java/com/powsybl/integrationtest/securityanalysis/jsonconfig/SecurityAnalysisTestPlanReader.java
+++ b/src/main/java/com/powsybl/integrationtest/securityanalysis/jsonconfig/SecurityAnalysisTestPlanReader.java
@@ -46,7 +46,7 @@ public class SecurityAnalysisTestPlanReader implements
         objectMapper = JsonUtil.createObjectMapper().registerModule(new SATestCaseModule());
     }
 
-    private static SecurityAnalysisTestCase buildFromJson(SecurityAnalysisTestCaseJson testCaseJson)
+    public static SecurityAnalysisTestCase buildFromJson(SecurityAnalysisTestCaseJson testCaseJson)
             throws IOException, URISyntaxException {
         Class<SecurityAnalysisTestPlanReader> cls = SecurityAnalysisTestPlanReader.class;
 
@@ -85,6 +85,10 @@ public class SecurityAnalysisTestPlanReader implements
                 iStateMonitors);
         SecurityAnalysisComputationResults sacResults = new SecurityAnalysisComputationResults(refNetwork, refResults);
         return new SecurityAnalysisTestCase(testCaseJson.getId(), sacParameters, sacResults);
+    }
+
+    public SecurityAnalysisTestPlanJson readTestPlan(InputStream input) throws IOException {
+        return objectMapper.readValue(input, SecurityAnalysisTestPlanJson.class);
     }
 
     @Override

--- a/src/main/java/com/powsybl/integrationtest/securityanalysis/jsonconfig/SecurityAnalysisTestPlanReader.java
+++ b/src/main/java/com/powsybl/integrationtest/securityanalysis/jsonconfig/SecurityAnalysisTestPlanReader.java
@@ -47,10 +47,7 @@ public class SecurityAnalysisTestPlanReader implements
         objectMapper = JsonUtil.createObjectMapper().registerModule(new SATestCaseModule());
     }
 
-    public static SecurityAnalysisTestCase buildFromJson(SecurityAnalysisTestCaseJson testCaseJson, Path resourcePath)
-            throws IOException, URISyntaxException {
-        Class<SecurityAnalysisTestPlanReader> cls = SecurityAnalysisTestPlanReader.class;
-
+    public static SecurityAnalysisTestCase buildFromJson(SecurityAnalysisTestCaseJson testCaseJson, Path resourcePath) throws IOException {
         // Load network from resources
         String network = testCaseJson.getInputNetwork();
         Network iNetwork = Network.read(Objects.requireNonNull(resourcePath.resolve(network)));

--- a/src/main/java/com/powsybl/integrationtest/utils/LoadFlowTestPlanUpdater.java
+++ b/src/main/java/com/powsybl/integrationtest/utils/LoadFlowTestPlanUpdater.java
@@ -1,0 +1,38 @@
+package com.powsybl.integrationtest.utils;
+
+import com.powsybl.integrationtest.loadflow.jsonconfig.LoadFlowTestCaseJson;
+import com.powsybl.integrationtest.loadflow.jsonconfig.LoadFlowTestPlanJson;
+import com.powsybl.integrationtest.loadflow.jsonconfig.LoadFlowTestPlanReader;
+import com.powsybl.integrationtest.loadflow.model.LoadFlowComputationResults;
+import com.powsybl.integrationtest.loadflow.model.LoadFlowTestCase;
+import com.powsybl.integrationtest.loadflow.model.LoadFlowTestRunner;
+import com.powsybl.loadflow.json.LoadFlowResultSerializer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public final class LoadFlowTestPlanUpdater {
+
+    private LoadFlowTestPlanUpdater() {
+    }
+
+    public static void main(String[] args) throws IOException, URISyntaxException {
+        LoadFlowTestPlanReader reader = new LoadFlowTestPlanReader();
+        LoadFlowTestRunner runner = new LoadFlowTestRunner();
+        Path resourceDirectory = Paths.get("src", "test", "resources");
+        try (InputStream res = Files.newInputStream(resourceDirectory.resolve("loadFlowTestPlan.json"))) {
+            LoadFlowTestPlanJson jsonPlan = reader.readTestPlan(res);
+
+            for (LoadFlowTestCaseJson testCaseJson : jsonPlan.getTestCases()) {
+                LoadFlowTestCase testCase = LoadFlowTestPlanReader.buildFromJson(testCaseJson, resourceDirectory);
+                LoadFlowComputationResults results = runner.runTestsWithoutChecks(testCase);
+                results.getNetwork().write("XIIDM", null, resourceDirectory.resolve(testCaseJson.getExpectedNetwork()));
+                LoadFlowResultSerializer.write(results.getResult(), resourceDirectory.resolve(testCaseJson.getExpectedResults()));
+            }
+        }
+    }
+}

--- a/src/main/java/com/powsybl/integrationtest/utils/SecurityAnalysisTestPlanUpdater.java
+++ b/src/main/java/com/powsybl/integrationtest/utils/SecurityAnalysisTestPlanUpdater.java
@@ -1,0 +1,46 @@
+package com.powsybl.integrationtest.utils;
+
+import com.powsybl.integrationtest.securityanalysis.jsonconfig.SecurityAnalysisTestCaseJson;
+import com.powsybl.integrationtest.securityanalysis.jsonconfig.SecurityAnalysisTestPlanJson;
+import com.powsybl.integrationtest.securityanalysis.jsonconfig.SecurityAnalysisTestPlanReader;
+import com.powsybl.integrationtest.securityanalysis.model.SecurityAnalysisComputationResults;
+import com.powsybl.integrationtest.securityanalysis.model.SecurityAnalysisTestCase;
+import com.powsybl.integrationtest.securityanalysis.model.SecurityAnalysisTestRunner;
+import com.powsybl.security.converter.SecurityAnalysisResultExporter;
+import com.powsybl.security.converter.SecurityAnalysisResultExporters;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.io.Writer;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public final class SecurityAnalysisTestPlanUpdater {
+
+    private SecurityAnalysisTestPlanUpdater() {
+    }
+
+    public static void main(String[] args) throws IOException, URISyntaxException {
+        SecurityAnalysisTestRunner runner = new SecurityAnalysisTestRunner();
+        SecurityAnalysisTestPlanReader reader = new SecurityAnalysisTestPlanReader();
+        Path resourceDirectory = Paths.get("src", "test", "resources");
+        try (InputStream res = Files.newInputStream(resourceDirectory.resolve("saTestPlan.json"))) {
+            SecurityAnalysisTestPlanJson jsonPlan = reader.readTestPlan(res);
+
+            for (SecurityAnalysisTestCaseJson testCaseJson : jsonPlan.getTestCases()) {
+                SecurityAnalysisTestCase testCase = SecurityAnalysisTestPlanReader.buildFromJson(testCaseJson, resourceDirectory);
+                SecurityAnalysisComputationResults results = runner.runTestsWithoutChecks(testCase);
+                results.getNetwork().write("XIIDM", null, resourceDirectory.resolve(testCaseJson.getExpectedNetwork()));
+                SecurityAnalysisResultExporter exporter = SecurityAnalysisResultExporters.getExporter("JSON");
+                try (Writer writer = Files.newBufferedWriter(resourceDirectory.resolve(testCaseJson.getExpectedResults()))) {
+                    exporter.export(results.getResults(), writer);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/com/powsybl/integrationtest/LoadFlowIntegrationTest.java
+++ b/src/test/java/com/powsybl/integrationtest/LoadFlowIntegrationTest.java
@@ -6,17 +6,23 @@
  */
 package com.powsybl.integrationtest;
 
+import com.powsybl.integrationtest.loadflow.jsonconfig.LoadFlowTestCaseJson;
+import com.powsybl.integrationtest.loadflow.jsonconfig.LoadFlowTestPlanJson;
 import com.powsybl.integrationtest.loadflow.jsonconfig.LoadFlowTestPlanReader;
 import com.powsybl.integrationtest.loadflow.model.LoadFlowComputationParameters;
 import com.powsybl.integrationtest.loadflow.model.LoadFlowComputationResults;
 import com.powsybl.integrationtest.loadflow.model.LoadFlowTestCase;
 import com.powsybl.integrationtest.loadflow.model.LoadFlowTestRunner;
 import com.powsybl.integrationtest.model.TestPlan;
+import com.powsybl.loadflow.json.LoadFlowResultSerializer;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringJoiner;
@@ -42,6 +48,29 @@ public class LoadFlowIntegrationTest {
                 StringJoiner joiner = new StringJoiner("\n");
                 errors.forEach(joiner::add);
                 throw new IllegalStateException(joiner.toString());
+            }
+        }
+    }
+
+    /**
+     * Update load flow test plan references by running the test cases and overriding the references with the results.
+     * This test is disabled and should only be used to update the references when you know what you are doing.
+     * @throws IOException
+     * @throws URISyntaxException
+     */
+    @Test @Disabled("See test description")
+    void updateLoadFlowReference() throws IOException, URISyntaxException {
+        LoadFlowTestPlanReader reader = new LoadFlowTestPlanReader();
+        LoadFlowTestRunner runner = new LoadFlowTestRunner();
+        try (InputStream res = getClass().getClassLoader().getResourceAsStream("loadFlowTestPlan.json")) {
+            LoadFlowTestPlanJson jsonPlan = reader.readTestPlan(res);
+
+            for (LoadFlowTestCaseJson testCaseJson : jsonPlan.getTestCases()) {
+                LoadFlowTestCase testCase = LoadFlowTestPlanReader.buildFromJson(testCaseJson);
+                LoadFlowComputationResults results = runner.runTestsWithoutChecks(testCase);
+                Path resourceDirectory = Paths.get("src", "test", "resources");
+                results.getNetwork().write("XIIDM", null, resourceDirectory.resolve(testCaseJson.getExpectedNetwork()));
+                LoadFlowResultSerializer.write(results.getResult(), resourceDirectory.resolve(testCaseJson.getExpectedResults()));
             }
         }
     }

--- a/src/test/java/com/powsybl/integrationtest/SecurityAnalysisIntegrationTest.java
+++ b/src/test/java/com/powsybl/integrationtest/SecurityAnalysisIntegrationTest.java
@@ -7,28 +7,21 @@
 package com.powsybl.integrationtest;
 
 import com.powsybl.integrationtest.model.TestPlan;
-import com.powsybl.integrationtest.securityanalysis.jsonconfig.SecurityAnalysisTestCaseJson;
-import com.powsybl.integrationtest.securityanalysis.jsonconfig.SecurityAnalysisTestPlanJson;
 import com.powsybl.integrationtest.securityanalysis.jsonconfig.SecurityAnalysisTestPlanReader;
 import com.powsybl.integrationtest.securityanalysis.model.SecurityAnalysisComputationParameters;
 import com.powsybl.integrationtest.securityanalysis.model.SecurityAnalysisComputationResults;
 import com.powsybl.integrationtest.securityanalysis.model.SecurityAnalysisTestCase;
 import com.powsybl.integrationtest.securityanalysis.model.SecurityAnalysisTestRunner;
-import com.powsybl.security.converter.SecurityAnalysisResultExporter;
-import com.powsybl.security.converter.SecurityAnalysisResultExporters;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
-import java.io.Writer;
 import java.net.URISyntaxException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.StringJoiner;
 
 /**
@@ -43,7 +36,8 @@ public class SecurityAnalysisIntegrationTest {
         SecurityAnalysisTestRunner runner = new SecurityAnalysisTestRunner();
         SecurityAnalysisTestPlanReader reader = new SecurityAnalysisTestPlanReader();
         try (InputStream res = getClass().getClassLoader().getResourceAsStream("saTestPlan.json")) {
-            TestPlan<SecurityAnalysisComputationParameters, SecurityAnalysisComputationResults, SecurityAnalysisTestCase> testPlan = reader.extractTestPlan(res);
+            Path resourcePath = Paths.get(Objects.requireNonNull(getClass().getClassLoader().getResource("saTestPlan.json")).toURI()).getParent();
+            TestPlan<SecurityAnalysisComputationParameters, SecurityAnalysisComputationResults, SecurityAnalysisTestCase> testPlan = reader.extractTestPlan(res, resourcePath);
             List<String> errors = new ArrayList<>();
             for (SecurityAnalysisTestCase testCase : testPlan.getTestCases()) {
                 errors.addAll(runner.runTests(testCase));
@@ -60,34 +54,6 @@ public class SecurityAnalysisIntegrationTest {
                     errors.forEach(joiner::add);
                 }
                 throw new IllegalStateException(joiner.toString());
-            }
-        }
-    }
-
-    /**
-     * Update security analysis test plan references by running the test cases and overriding the references with the results.
-     * This test is disabled and should only be used to update the references when you know what you are doing.
-     * @throws IOException
-     * @throws URISyntaxException
-     */
-    @Test @Disabled("See test description")
-    void updateSaReference() throws IOException, URISyntaxException {
-        SecurityAnalysisTestRunner runner = new SecurityAnalysisTestRunner();
-        SecurityAnalysisTestPlanReader reader = new SecurityAnalysisTestPlanReader();
-        try (InputStream res = getClass().getClassLoader().getResourceAsStream("saTestPlan.json")) {
-            SecurityAnalysisTestPlanJson jsonPlan = reader.readTestPlan(res);
-
-            for (SecurityAnalysisTestCaseJson testCaseJson : jsonPlan.getTestCases()) {
-                SecurityAnalysisTestCase testCase = SecurityAnalysisTestPlanReader.buildFromJson(testCaseJson);
-                SecurityAnalysisComputationResults results = runner.runTestsWithoutChecks(testCase);
-                Path resourceDirectory = Paths.get("src", "test", "resources");
-                results.getNetwork().write("XIIDM", null, resourceDirectory.resolve(testCaseJson.getExpectedNetwork()));
-                SecurityAnalysisResultExporter exporter = SecurityAnalysisResultExporters.getExporter("JSON");
-                try (Writer writer = Files.newBufferedWriter(resourceDirectory.resolve(testCaseJson.getExpectedResults()))) {
-                    exporter.export(results.getResults(), writer);
-                } catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                }
             }
         }
     }


### PR DESCRIPTION
Add two tests, disabled by default, updating the references for the load flow and security analysis test plan when launched.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
