### PR TITLE
CI: New branch name pattern for full Sonar analyses

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'main'
       - 'release-v**'
+      - 'full-sonar-analysis-**'
   pull_request:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines

**What kind of change does this PR introduce?**
Feature

**What is the current behavior?**
Full sonar analyses are only performed on main and release-v** branches.

**What is the new behavior (if this is a feature change)?**
Full sonar analyses will also be performed for full-sonar-analysis-** branches.

**Other information**:
This PR is not sufficient. To have full sonar analyses on these branches, the pattern must also be added to the "long-living branches" definition in the SonarCloud project.
(To have a full report, the analysis must be performed on a branch and not a PR - this is the purpose of this PR - AND the branch must be a long-living one.)

See https://github.com/powsybl/powsybl-diagram/pull/541 for more information.
