### PR TITLE
Bump core to 6.0.0 and open-loadflow to 1.3.0

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,7 +36,7 @@ jobs:
           ref: refs/heads/main
         
       - name: Build and install powsybl-core with Maven
-          run: mvn --batch-mode -DskipTests=true --file ../powsybl-core/pom.xml install
+        run: mvn --batch-mode -DskipTests=true --file ../powsybl-core/pom.xml install
 
       - name: Checkout powsybl-open-loadflow latest sources
         uses: actions/checkout@v1
@@ -44,6 +44,9 @@ jobs:
           repository: powsybl/powsybl-open-loadflow
           ref: refs/heads/draft_dirty_bump_core_6.0.0
         
+      - name: Build and install powsybl-open-loadflow with Maven
+        run: mvn --batch-mode -DskipTests=true --file ../powsybl-open-loadflow/pom.xml install
+
       - name: Build with Maven
         run: mvn --batch-mode -Pjacoco install
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v1
         with:
           repository: powsybl/powsybl-open-loadflow
-          ref: refs/heads/draft_dirty_bump_core_6.0.0
+          ref: refs/heads/main
         
       - name: Build and install powsybl-open-loadflow with Maven
         run: mvn --batch-mode -DskipTests=true --file ../powsybl-open-loadflow/pom.xml install

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,15 +29,6 @@ jobs:
         with:
           java-version: 17
 
-      - name: Checkout powsybl-open-loadflow latest sources
-        uses: actions/checkout@v1
-        with:
-          repository: powsybl/powsybl-open-loadflow
-          ref: refs/heads/main
-        
-      - name: Build and install powsybl-open-loadflow with Maven
-        run: mvn --batch-mode -DskipTests=true --file ../powsybl-open-loadflow/pom.xml install
-
       - name: Build with Maven
         run: mvn --batch-mode -Pjacoco install
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,6 +29,21 @@ jobs:
         with:
           java-version: 17
 
+      - name: Checkout powsybl-core latest sources
+        uses: actions/checkout@v1
+        with:
+          repository: powsybl/powsybl-core
+          ref: refs/heads/main
+        
+      - name: Build and install powsybl-core with Maven
+          run: mvn --batch-mode -DskipTests=true --file ../powsybl-core/pom.xml install
+
+      - name: Checkout powsybl-open-loadflow latest sources
+        uses: actions/checkout@v1
+        with:
+          repository: powsybl/powsybl-open-loadflow
+          ref: refs/heads/draft_dirty_bump_core_6.0.0
+        
       - name: Build with Maven
         run: mvn --batch-mode -Pjacoco install
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,15 +29,6 @@ jobs:
         with:
           java-version: 17
 
-      - name: Checkout powsybl-core latest sources
-        uses: actions/checkout@v1
-        with:
-          repository: powsybl/powsybl-core
-          ref: refs/heads/main
-        
-      - name: Build and install powsybl-core with Maven
-        run: mvn --batch-mode -DskipTests=true --file ../powsybl-core/pom.xml install
-
       - name: Checkout powsybl-open-loadflow latest sources
         uses: actions/checkout@v1
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-parent</artifactId>
-        <version>14</version>
+        <version>15</version>
         <relativePath/>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <powsybl-core.version>6.0.0-SNAPSHOT</powsybl-core.version>
+        <powsybl-core.version>6.0.0-RC1</powsybl-core.version>
         <powsybl-open-loadflow.version>1.3.0-SNAPSHOT</powsybl-open-loadflow.version>
         <junit-jupiter.version>5.5.2</junit-jupiter.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-parent</artifactId>
-        <version>13</version>
+        <version>14</version>
         <relativePath/>
     </parent>
 
@@ -47,8 +47,8 @@
 
     <properties>
         <java.version>17</java.version>
-        <powsybl-core.version>5.3.2</powsybl-core.version>
-        <powsybl-open-loadflow.version>1.2.3</powsybl-open-loadflow.version>
+        <powsybl-core.version>6.0.0-SNAPSHOT</powsybl-core.version>
+        <powsybl-open-loadflow.version>1.3.0-SNAPSHOT</powsybl-open-loadflow.version>
         <junit-jupiter.version>5.5.2</junit-jupiter.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
 
     <properties>
         <java.version>17</java.version>
-        <powsybl-core.version>6.0.0-RC1</powsybl-core.version>
-        <powsybl-open-loadflow.version>1.3.0-SNAPSHOT</powsybl-open-loadflow.version>
+        <powsybl-core.version>6.0.0</powsybl-core.version>
+        <powsybl-open-loadflow.version>1.3.0</powsybl-open-loadflow.version>
         <junit-jupiter.version>5.5.2</junit-jupiter.version>
     </properties>
 

--- a/src/test/resources/sareferences/micro-t1.json
+++ b/src/test/resources/sareferences/micro-t1.json
@@ -36,7 +36,7 @@
       } ],
       "busResults" : [ {
         "voltageLevelId" : "8bbd7e74-ae20-4dce-8780-c20f8e18c2e0",
-        "busId" : "8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0",
+        "busId" : "364c9ca2-0d1d-4363-8f46-e586f8f66a8c",
         "v" : 115.5,
         "angle" : -8.11884530695139
       } ],
@@ -88,7 +88,7 @@
       } ],
       "busResults" : [ {
         "voltageLevelId" : "8bbd7e74-ae20-4dce-8780-c20f8e18c2e0",
-        "busId" : "8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0",
+        "busId" : "364c9ca2-0d1d-4363-8f46-e586f8f66a8c",
         "v" : 115.5,
         "angle" : -45.10064083246836
       } ],
@@ -137,7 +137,7 @@
       } ],
       "busResults" : [ {
         "voltageLevelId" : "8bbd7e74-ae20-4dce-8780-c20f8e18c2e0",
-        "busId" : "8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0",
+        "busId" : "364c9ca2-0d1d-4363-8f46-e586f8f66a8c",
         "v" : 115.5,
         "angle" : -8.382673643304331
       } ],
@@ -195,7 +195,7 @@
       } ],
       "busResults" : [ {
         "voltageLevelId" : "8bbd7e74-ae20-4dce-8780-c20f8e18c2e0",
-        "busId" : "8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0",
+        "busId" : "364c9ca2-0d1d-4363-8f46-e586f8f66a8c",
         "v" : 115.5,
         "angle" : -45.01853495962268
       } ],
@@ -244,7 +244,7 @@
       } ],
       "busResults" : [ {
         "voltageLevelId" : "8bbd7e74-ae20-4dce-8780-c20f8e18c2e0",
-        "busId" : "8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0",
+        "busId" : "364c9ca2-0d1d-4363-8f46-e586f8f66a8c",
         "v" : 115.5,
         "angle" : -8.344693401665431
       } ],
@@ -293,7 +293,7 @@
       } ],
       "busResults" : [ {
         "voltageLevelId" : "8bbd7e74-ae20-4dce-8780-c20f8e18c2e0",
-        "busId" : "8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0",
+        "busId" : "364c9ca2-0d1d-4363-8f46-e586f8f66a8c",
         "v" : 115.5,
         "angle" : -8.11336192064182
       } ],
@@ -348,7 +348,7 @@
       } ],
       "busResults" : [ {
         "voltageLevelId" : "8bbd7e74-ae20-4dce-8780-c20f8e18c2e0",
-        "busId" : "8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0",
+        "busId" : "364c9ca2-0d1d-4363-8f46-e586f8f66a8c",
         "v" : 115.5,
         "angle" : -45.01811008708234
       } ],
@@ -392,7 +392,7 @@
       "branchResults" : [ ],
       "busResults" : [ {
         "voltageLevelId" : "8bbd7e74-ae20-4dce-8780-c20f8e18c2e0",
-        "busId" : "8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0",
+        "busId" : "364c9ca2-0d1d-4363-8f46-e586f8f66a8c",
         "v" : 115.5,
         "angle" : -8.59433037164498
       } ],
@@ -444,7 +444,7 @@
       } ],
       "busResults" : [ {
         "voltageLevelId" : "8bbd7e74-ae20-4dce-8780-c20f8e18c2e0",
-        "busId" : "8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0",
+        "busId" : "364c9ca2-0d1d-4363-8f46-e586f8f66a8c",
         "v" : 115.5,
         "angle" : -8.761785228002786
       } ],
@@ -496,7 +496,7 @@
       } ],
       "busResults" : [ {
         "voltageLevelId" : "8bbd7e74-ae20-4dce-8780-c20f8e18c2e0",
-        "busId" : "8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0",
+        "busId" : "364c9ca2-0d1d-4363-8f46-e586f8f66a8c",
         "v" : 115.5,
         "angle" : -9.283953189490807
       } ],
@@ -545,7 +545,7 @@
       } ],
       "busResults" : [ {
         "voltageLevelId" : "8bbd7e74-ae20-4dce-8780-c20f8e18c2e0",
-        "busId" : "8bbd7e74-ae20-4dce-8780-c20f8e18c2e0_0",
+        "busId" : "364c9ca2-0d1d-4363-8f46-e586f8f66a8c",
         "v" : 115.5,
         "angle" : -8.487633345768359
       } ],


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Update dependencies.


**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**
Security analysis in node breaker networks now return results for each busbar section in a monitored voltage level (powsybl/powsybl-open-loadflow#603). Reference to bus results has been updated in the expected results for micro-t1.

**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
